### PR TITLE
Master

### DIFF
--- a/src/military_symbol/name_to_sidc.py
+++ b/src/military_symbol/name_to_sidc.py
@@ -139,7 +139,7 @@ def name_to_symbol(name_string: str, symbol_schema: SymbolSchema, verbose: bool 
     # Step 1: Detect standard identity
 
     if template is None or not template.standard_identity_fixed:
-        standard_identity, new_name_string = fuzzy_match(symbol_schema, name_string,
+        standard_identity, new_name_string = fuzzy_match(symbol_schema, name_string.lower(),
                                                      symbol_schema.standard_identities.values(), match_longest=True)
 
         if standard_identity is None:


### PR DESCRIPTION
adding a .lower() seems to fix the issue with an extra X symbol for brigade and above when using Brigade instead of brigade. 