### PR TITLE
Fix typos in entities name

### DIFF
--- a/Resources/Symbol schema.json
+++ b/Resources/Symbol schema.json
@@ -1441,7 +1441,7 @@
 								},
 								"03": {
 									"name": "light tactical landing approach radar *",
-									"type": "fo", "overlay": ["111100", "0XLight", "OXRightR", "0XLeftE"]
+									"type": "fo", "overlay": ["111100", "0XLight", "0XRightR", "0XLeftE"]
 								},
 								"04": {"name": "medium *", "type": "fo", "overlay": ["111100", "0XMedium"]},
 								"05": {
@@ -1450,7 +1450,7 @@
 								},
 								"06": {
 									"name": "medium tactical landing approach radar *",
-									"type": "fo", "overlay": ["111100", "0XMedium", "OXRightR", "0XLeftE"]
+									"type": "fo", "overlay": ["111100", "0XMedium", "0XRightR", "0XLeftE"]
 								},
 								"07": {"name": "heavy *", "type": "fo", "overlay": ["111100", "0XHeavy"]},
 								"08": {

--- a/src/military_symbol/symbols.json
+++ b/src/military_symbol/symbols.json
@@ -4280,7 +4280,7 @@
          "overlay": [
           "111100",
           "0XLight",
-          "OXRightR",
+          "0XRightR",
           "0XLeftE"
          ]
         },
@@ -4307,7 +4307,7 @@
          "overlay": [
           "111100",
           "0XMedium",
-          "OXRightR",
+          "0XRightR",
           "0XLeftE"
          ]
         },


### PR DESCRIPTION
Hi! Firstly, thanks for your work.
This PR fixes a FileNotFoundError exception for some entities. Just "0" instead of "O" :)